### PR TITLE
TheSmartNoob880--misc_tweaks_and_villager_nerfs

### DIFF
--- a/kubejs/server_scripts/misc_recipes.js
+++ b/kubejs/server_scripts/misc_recipes.js
@@ -22,6 +22,10 @@ onEvent('tags.items', event => {
 
 	//give coal it's own tag
 	event.add(`mbm2:coal`, 'minecraft:coal')
+
+	//smokey quartz producing molten quartz fix
+	event.remove('forge:storage_blocks/quartz', 'botania:dark_quartz')
+	event.remove('c:quartz_blocks', 'botania:dark_quartz')
 	
  });
 
@@ -476,5 +480,9 @@ event.custom({
 	  {"tag": 'forge:gems/sapphire',
 		"count": 1}]
 }).id(`mbm2:crystallizer/sapphire_from_vincyte`)	
-		
+
+//Flux Networks Flux Core recipe change
+event.remove({output: '4x fluxnetworks:flux_core'})
+event.shaped('4x fluxnetworks:flux_core', ['ABC','BDB','CBA'], {A: 'tconstruct:ender_slime_crystal',B: 'fluxnetworks:flux_dust',C: 'powah:dielectric_paste',D: 'powah:ender_gate_niotic'}).id('mbm2:crafting/fluxnetworks_flux_core')
+
 });

--- a/kubejs/server_scripts/mod_scripts/powah.js
+++ b/kubejs/server_scripts/mod_scripts/powah.js
@@ -40,7 +40,7 @@ onEvent('recipes', event => {
   event.remove({id: 'powah:energizing/uraninite_from_ore_dense'})
   event.remove({id: 'powah:energizing/uraninite_from_ore_poor'})
   
-  
+  event.remove({ id: 'powah:crafting/reactor_basic'})
   
 
 	//Dielectric Casing

--- a/kubejs/server_scripts/mod_scripts/tinkers.js
+++ b/kubejs/server_scripts/mod_scripts/tinkers.js
@@ -1,3 +1,8 @@
+onEvent('tags.items', event => {
+	//Sheetmetal Cast can go in cast chest now
+	event.add(`tconstruct:casts`, 'kubejs:sheetmetal_cast')
+})
+
 onEvent('recipes', event => {
 
 	//Puny Smelting Guide Book

--- a/kubejs/server_scripts/new_part_recipes.js
+++ b/kubejs/server_scripts/new_part_recipes.js
@@ -443,6 +443,13 @@ onEvent('recipes', event => {
 			  ], {
 				R: `#forge:rings/${item.material}`,
 			  }).id(`mbm2:crafting/${item.material}_sprockets`)
+			//Cheaper recipe
+			event.recipes.multiblocked.multiblock("mechanical_crafting")
+			.inputItem(`3x #forge:rings/${item.material}`)
+			.outputItem(Item.of(`#forge:sprockets/${item.material}`))
+			.setPerTick(true)
+			.inputFE(2000)
+			.duration(100)
 		}
 	}
 

--- a/kubejs/server_scripts/villager.js
+++ b/kubejs/server_scripts/villager.js
@@ -1,0 +1,16 @@
+onEvent('morejs.villager.trades', event =>{
+
+    event.removeModdedTrades(['pneumaticcraft:mechanic'], 1)
+    event.addTrade('pneumaticcraft:mechanic', 1, [Item.of('minecraft:emerald', 9), Item.of('#forge:ingots/steel', 3)], Item.of('pneumaticcraft:compressed_iron_block', 1))
+    event.addTrade('pneumaticcraft:mechanic', 1, [Item.of('minecraft:emerald', 8)], Item.of('pneumaticcraft:pcb_blueprint', 1))
+    event.addTrade('pneumaticcraft:mechanic', 1, [Item.of('minecraft:emerald', 4)], Item.of('pneumaticcraft:air_canister', 1))
+    event.addTrade('pneumaticcraft:mechanic', 1, [Item.of('minecraft:emerald', 2)], Item.of('pneumaticcraft:pressure_tube', 8))
+    event.removeModdedTrades(['pneumaticcraft:mechanic'], 5)
+    event.addTrade('pneumaticcraft:mechanic', 5, [Item.of('minecraft:emerald', 10)], Item.of('pneumaticcraft:stop_worm', 1))
+    event.addTrade('pneumaticcraft:mechanic', 5, [Item.of('minecraft:emerald', 10)], Item.of('pneumaticcraft:nuke_virus', 1))
+    event.addTrade('pneumaticcraft:mechanic', 5, [Item.of('minecraft:emerald', 20), Item.of('pneumaticcraft:empty_pcb')], Item.of('pneumaticcraft:printed_circuit_board', 1))
+    event.addTrade('pneumaticcraft:mechanic', 5, [Item.of('minecraft:emerald', 15)], Item.of('pneumaticcraft:micromissiles', 1))
+    event.addTrade('pneumaticcraft:mechanic', 5, [Item.of('minecraft:emerald', 25)], Item.of('pneumaticcraft:drone', 1))
+
+
+})

--- a/kubejs/startup_scripts/_master_material_list.js
+++ b/kubejs/startup_scripts/_master_material_list.js
@@ -1129,7 +1129,7 @@ global.newMaterialParts = [
       'color': 0x484e5e,
       'type': 'alloy',
       'tier': 5,
-      'itemParts': ['ingot', 'nugget', 'dust',  'plate', 'gear', 'rod', 'plating', 'hull_panel'],
+      'itemParts': ['ingot', 'nugget', 'dust',  'plate', 'gear', 'rod', 'plating', 'hull_panel', 'bolt'],
       'blockParts': ['storage_block', 'scaffolding', 'frame_box', 'hull_casing'],
       'fluid_id': 'kubejs:molten_inconel',
       'fluid': 'thick',


### PR DESCRIPTION
Changelog:
Powah: Removed the duplicate basic reactor recipe.
Tinkers Construct: You can now put the sheet metal cast inside the cast chest with the others!
Flux Networks: Flux cores now have a new recipe
You can now make sprockets in the Mechanical crafter for 3 rings instead of 5.

Bugfixes: 
Melting smokey quartz blocks in the foundry or smeltery now actually gives liquid smoke.
Inconel now has it's missing bolt.
